### PR TITLE
Refactor sockets

### DIFF
--- a/src/client/actions/socket.js
+++ b/src/client/actions/socket.js
@@ -3,17 +3,39 @@ export const CREATE_GAME = 'CREATE_GAME';
 export const JOIN_GAME = 'JOIN_GAME';
 
 // Action objects
-export const createGame = ({ webRTCId, socketId }) => ({
-  type: 'socket',
-  data: { call: '/game', path: '/create', webRTCId, socketId },
-});
 
-export const joinGame = ({ room, webRTCId, socketId }) => ({
+/*
+** Update back-end player payload (ex: nickname).
+*/
+export const socketUpdatePlayer = settings => ({
   type: 'socket',
-  data: { call: '/game', path: '/join', webRTCId, socketId, room },
+  data: { call: '/player', path: '/update', settings },
 });
-
-export const setPlayerNickname = ({ nickname, webRTCId, room }) => ({
+/*
+** Create game and set player as master. Will return a game updated to all player (only master).
+*/
+export const socketCreateGame = () => ({
   type: 'socket',
-  data: { call: '/player', path: '/nickname', webRTCId, nickname, room },
+  data: { call: '/game', path: '/create' },
+});
+/*
+** Join existing game. Will return a game updated to all players.
+*/
+export const socketJoinGame = gameId => ({
+  type: 'socket',
+  data: { call: '/game', path: '/join', gameId },
+});
+/*
+** Leave existing game. Will return a game updated to all players.
+*/
+export const socketLeaveGame = gameId => ({
+  type: 'socket',
+  data: { call: '/game', path: '/leave', gameId },
+});
+/*
+** Update existing game. Will return a game updated to all players.
+*/
+export const socketUpdateGame = (gameId, settings) => ({
+  type: 'socket',
+  data: { call: '/game', path: '/update', gameId, settings },
 });

--- a/src/client/socket/handleGameSocket.js
+++ b/src/client/socket/handleGameSocket.js
@@ -1,0 +1,26 @@
+import store from '../store';
+import actions from '../actions';
+
+const { updateGame } = actions;
+
+
+function update(data) {
+  const { game } = data;
+  store.dispatch(updateGame(game));
+}
+
+
+export default function (data) {
+  const { path } = data;
+  console.log(`socket /game${path}`);
+  switch (path) {
+    case '/update': {
+      update(data);
+      break;
+    }
+    default: {
+      console.log('default triggered');
+    }
+  }
+}
+

--- a/src/client/socket/handlePlayerSocket.js
+++ b/src/client/socket/handlePlayerSocket.js
@@ -1,0 +1,3 @@
+export default function (data) {
+
+}

--- a/src/client/socket/handleTetrisSocket.js
+++ b/src/client/socket/handleTetrisSocket.js
@@ -1,0 +1,3 @@
+export default function (data) {
+
+}

--- a/src/client/socket/index.js
+++ b/src/client/socket/index.js
@@ -1,0 +1,27 @@
+import io from 'socket.io-client';
+
+import handleGameSocket from './handleGameSocket';
+import handleTetrisSocket from './handleTetrisSocket';
+import handlePlayerSocket from './handlePlayerSocket';
+
+
+let client = null;
+
+export function getClient() {
+  return client;
+}
+
+export function closeClient() {
+  if (client) {
+    client.close();
+    client = null;
+  }
+}
+
+export function openClient() {
+  client = io.connect('/');
+
+  client.on('/game', data => handleGameSocket(data));
+  client.on('/tetris', data => handleTetrisSocket(data));
+  client.on('/player', data => handlePlayerSocket(data));
+}

--- a/src/server/webSocket/socketManager.js
+++ b/src/server/webSocket/socketManager.js
@@ -6,6 +6,8 @@ import handlePieceSocket from './handlePieceSocket';
 import handlePlayerSocket from './handlePlayerSocket';
 import handleGameSocket from './handleGameSocket';
 
+import Player from '../classes/Player';
+
 let io = null;
 
 /**
@@ -19,11 +21,28 @@ export function listen(server) {
 
   io.on('connection', (socket) => {
     logger.info(`Socket connected: ${socket.id}`);
-    io.socketId = socket.id;
 
-    socket.on('/game', data => handleGameSocket(data));
-    socket.on('/piece', data => handlePieceSocket(data));
-    socket.on('/player', data => handlePlayerSocket(data));
+    /*
+    ** Add incoming socket messages handlers
+    */
+    socket.on('/game', data => handleGameSocket(socket.id, data));
+    socket.on('/piece', data => handlePieceSocket(socket.id, data));
+    socket.on('/player', data => handlePlayerSocket(socket.id, data));
+
+    /*
+    ** Create new Player.
+    */
+    const { allPlayers } = Player;
+    allPlayers.push(new Player(socket));
+
+    /**
+     * Handle deconnexion
+     */
+    socket.on('disconnect', () => {
+      const data = { path: '/deconnexion' };
+      handleGameSocket(socket.id, data);
+      handlePlayerSocket(socket.id, data);
+    });
   });
 
   return io;


### PR DESCRIPTION
## SERVER

**Every socket opening leads to the creation of a user!**

### RECEPTION
- I kept the architecture
- I removed almost all events (path) and rename them for **/game** and **/player**

### EMISSION
- Socket object is part of User Class
- Emission events are handled by the broadcast methods of classes
- Can be refactored

## CLIENT

### RECEPTION
- Socket was instanced at opening. Remove that.
- Socket receivers are no longer in middleware.
- Socket receivers and socket client helper are transferred into a socket repository.
  - *helpers/webSocket* is now *socket/index*
  - Could not do better than use `store.dispatch` and `store.getState` as global.

### EMISSION
- Socket emitters are still handled by middleware.
  - I added a prefix before all socket emission action.
  - I renamed the actions.


